### PR TITLE
Change to make compatible with Ruby 1.8.7

### DIFF
--- a/lib/wordpress/dump.rb
+++ b/lib/wordpress/dump.rb
@@ -4,7 +4,7 @@ module Refinery
       attr_reader :doc
 
       def initialize(file_name)
-        file_name = File.absolute_path(file_name)
+        file_name = File.expand_path(file_name)
 
         raise "Given file '#{file_name}' no file or not readable." \
           unless File.file?(file_name) && File.readable?(file_name)


### PR DESCRIPTION
Use File.expand_path instead of File.absolute_path to work with Ruby 1.8.7 .  

Thanks for making this script, it was very helpful!
